### PR TITLE
fix: Increase startup timeout for redact-gpu.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
-      start_period: "120s"
+      start_period: "900s"
     restart: always
     runtime: nvidia
     environment:


### PR DESCRIPTION
Multi-gpu environments lead to multi-minute startup time and the timeout was too low for these. 4 gpu on washington require about 700s sartup time.