### PR TITLE
Release/redact inferv2.5.1 opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following GPU-specific containers exist, and can be used only with the speci
 
 | Standard Image   | T4 Optimized Image            | A100 Optimized Image            | 2080TI Optimized Image     |
 |------------------|-------------------------------|---------------------------------|----------------------------|
+| redact-gpu:2.5.1 | redact-gpu:2.5.1-T4           | redact-gpu:2.5.1-A100           | redact-gpu:2.5.1-2080ti    |
 | redact-gpu:2.5.0 | redact-gpu:2.5.0-T4           | redact-gpu:2.5.0-A100           | redact-gpu:2.5.0-2080ti    |
 | redact-gpu:2.4.0 | redact-gpu:2.4.0-optimized-T4 | redact-gpu:2.4.0-optimized-A100 |                            |
 | redact-gpu:2.3.1 | redact-gpu:2.3.1-trt-T4       |                                 |                            |

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,6 +1,6 @@
 REDACT_IMAGE="docker.brighter.ai/redact:v5.12.0"
-REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.5.0"
-REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.1"
+REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.5.1"
+REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.2"
 
 REDACT_CONTAINER_NAME="redact"
 REDACT_GPU_CONTAINER_NAME="redact-gpu"


### PR DESCRIPTION
This PR bumps we the version for `redact-infer` aka `redact-gpu` to 2.5.1. The update image types are:
- standard
- T4 optimized
- A100 optimized
- 2080TI Optimized

There is also a new folder to easily run test jobs for DNAT and blur.