### PR TITLE
[PHX-1117] updating to docker compose version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ if you also want to start the graphical user interface add the `-u` flag
 3. Redact can be shut down with the following script:
 `./stop_redact.sh`
 
+IMPORTANT: The scripts require to run docker compose under the command `docker compose`. That is compose v2 and the compose plugin for docker. In compose v1 one needed to run `docker-compose`. [More](https://docs.docker.com/compose/migrate/). 
+
 ### Configuration
 
 The configuration of the docker-compose setup can be changed within the [docker-compose.env](./docker-compose.env) file.

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -41,7 +41,7 @@ if [ ${ui+x} ]; then
 fi
 
 export HOST_IP=$(hostname -I | awk '{print $1}')
-docker-compose -f docker-compose.yaml up --force-recreate -d --remove-orphans ${services}
+docker compose -f docker-compose.yaml up --force-recreate -d --remove-orphans ${services}
 
 # print some urls
 echo "redact API running at http://${HOST_IP}:${REDACT_API_PORT}"

--- a/stop_redact.sh
+++ b/stop_redact.sh
@@ -7,4 +7,4 @@ set +a
 
 # start containers
 export HOST_IP=$(hostname -I | awk '{print $1}')
-docker-compose down --remove-orphans
+docker compose down --remove-orphans


### PR DESCRIPTION
This PR updates the `./start_redact.sh` and `./stop_redact.sh` to use docker compose version 2. 
The updating of the general brighter AI confluence documentation is ongoing and can be followed [here](https://brighterai.atlassian.net/browse/PHX-1117?atlOrigin=eyJpIjoiMTRkMzAxZTEwYmM5NDMyZTlkMDQ4Mjc2Yjg1YzE3ZGUiLCJwIjoiaiJ9).