### PR TITLE
Release/redact infer v2.6.0 redact 5.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following GPU-specific containers exist, and can be used only with the speci
 
 | Standard Image   | T4 Optimized Image            | A100 Optimized Image            | 2080TI Optimized Image     |
 |------------------|-------------------------------|---------------------------------|----------------------------|
+| redact-gpu:2.6.0 | redact-gpu:2.6.0-T4           | redact-gpu:2.6.0-A100           | redact-gpu:2.6.0-2080ti    |
 | redact-gpu:2.5.1 | redact-gpu:2.5.1-T4           | redact-gpu:2.5.1-A100           | redact-gpu:2.5.1-2080ti    |
 | redact-gpu:2.5.0 | redact-gpu:2.5.0-T4           | redact-gpu:2.5.0-A100           | redact-gpu:2.5.0-2080ti    |
 | redact-gpu:2.4.0 | redact-gpu:2.4.0-optimized-T4 | redact-gpu:2.4.0-optimized-A100 |                            |

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,5 +1,5 @@
-REDACT_IMAGE="docker.brighter.ai/redact:v5.12.0"
-REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.5.1"
+REDACT_IMAGE="docker.brighter.ai/redact:v5.13.0"
+REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.6.0"
 REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.2"
 
 REDACT_CONTAINER_NAME="redact"


### PR DESCRIPTION
This PR updates for redact 5.13.0 and redact infer v2.6.0. It was tested on internal brighter AI server. 