### PR TITLE
Release/redact infer v2.7.0 redact 5.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following GPU-specific containers exist, and can be used only with the speci
 
 | Standard Image   | T4 Optimized Image            | A100 Optimized Image            | 2080TI Optimized Image     |
 |------------------|-------------------------------|---------------------------------|----------------------------|
+| redact-gpu:2.7.0 | redact-gpu:2.7.0-T4           | redact-gpu:2.7.0-A100           | redact-gpu:2.7.0-2080ti    |
 | redact-gpu:2.6.1 | redact-gpu:2.6.1-T4           | redact-gpu:2.6.1-A100           | redact-gpu:2.6.1-2080ti    |
 | redact-gpu:2.6.0 | redact-gpu:2.6.0-T4           | redact-gpu:2.6.0-A100           | redact-gpu:2.6.0-2080ti    |
 | redact-gpu:2.5.1 | redact-gpu:2.5.1-T4           | redact-gpu:2.5.1-A100           | redact-gpu:2.5.1-2080ti    |

--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ Make sure you have access to your redact license file. For this guide, we'll ass
 0. (optional) Change the default configuration as described [below](#configuration)
 
 1. Start redact in default configuration by running:
-`./start_redact.sh -d`
-the `-d` flag is recommended to run the containers in detached mode.
-if you also want to start the graphical user interface add the `-u` flag
-`./start_redact.sh -du`
+`./start_redact.sh`
 
 2. Start anonymizing using the ui ( http://$HOSTIP:8080/ui ), sra ( http://$HOSTIP:8080/sra ), or the flassger interface( http://$HOSTIP:8787 ).
 
@@ -38,6 +35,7 @@ if you also want to start the graphical user interface add the `-u` flag
 `./stop_redact.sh`
 
 IMPORTANT: The scripts require to run docker compose under the command `docker compose`. That is compose v2 and the compose plugin for docker. In compose v1 one needed to run `docker-compose`. [More](https://docs.docker.com/compose/migrate/).
+
 
 ### Configuration
 
@@ -124,3 +122,16 @@ To allow systemd to manage the service, run `sudo systemctl enable redact.servic
 The service can be disabled using `sudo systemctl disable redact.service`. This will tell systemd not to manage the service anymore, but will not stop the service. `sudo systemctl stop redact.service` will still need to be run to stop the service. Whether or not the service is enabled can be checked with `sudo systemctl is-enabled redact.service`.
 
 The current health and status of the service can be seen by running `sudo systemctl status redact.service`, and the status of the docker containers themselves can be seen by running `docker ps` and interacting with the `redact` and `redact-gpu` containers. 
+
+### Other command flags for start_redact.sh
+
+#### -a (attach) flag
+
+The `-a` flag is recommended to run the containers in attached mode, aka launch in foreground.
+You can combine this with the graphical user interface by adding the `-u` flag
+`./start_redact.sh -du`
+
+#### -u (UI or utils) flag
+
+This flag is indicating that the utils container should be started, which 
+contains notably the UI functionality.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Log in to the brighter AI docker registry with your credentials:
 
 `docker login docker.brighter.ai -u enterprise -p <api-key>`
 
-Make sure you have access to your redact license file. For this guide, we'll assume that it's stored under `/home/${USER}/license.bal` and named `./license.bal`
+Make sure you have access to your redact license file. For this guide, we'll assume that it's stored in this project and named `./license.bal`
 
 | Usage-based licenses | If you're using a usage-based license you must have an active internet connection at all times or run the Redact-License-Server!       |
 |-------------|:------------------------|

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The current health and status of the service can be seen by running `sudo system
 
 The `-a` flag is recommended to run the containers in attached mode, aka launch in foreground.
 You can combine this with the graphical user interface by adding the `-u` flag
-`./start_redact.sh -du`
+`./start_redact.sh -au`
 
 #### -u (UI or utils) flag
 

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,5 +1,5 @@
-REDACT_IMAGE="docker.brighter.ai/redact:v5.13.1"
-REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.6.1"
+REDACT_IMAGE="docker.brighter.ai/redact:v5.14.0"
+REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.7.0"
 REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.4"
 
 REDACT_CONTAINER_NAME="redact"

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,6 +1,6 @@
 REDACT_IMAGE="docker.brighter.ai/redact:v5.14.0"
 REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.7.0"
-REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.4"
+REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.8"
 
 REDACT_CONTAINER_NAME="redact"
 REDACT_GPU_CONTAINER_NAME="redact-gpu"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     ports:
       - '${REDACT_API_PORT}:8787'
     volumes:
-      - '${INSTALLATION_DIR}/${REDACT_LICENSE_FILE}:/license.bal'
+      - ${PWD}/${REDACT_LICENSE_FILE}:/license.bal
     environment:
       REDACT_INFER_METRICS_URL: 'redact-gpu:8000'
       REDACT_GPU_URL: 'redact-gpu:8001'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,6 @@ services:
       redact:
         condition: service_healthy
     ports:
-      - '${REDACT_UI_PORT}:80'
+      - '${REDACT_UI_PORT}:8080'
     environment:
       REDACT_URL: http://${HOST_IP}:${REDACT_API_PORT}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     ports:
       - '${REDACT_API_PORT}:8787'
     volumes:
-      - ${PWD}/${REDACT_LICENSE_FILE}:/license.bal
+      - ${INSTALLATION_DIR}/${REDACT_LICENSE_FILE}:/license.bal
     environment:
       REDACT_INFER_METRICS_URL: 'redact-gpu:8000'
       REDACT_GPU_URL: 'redact-gpu:8001'

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ if [ $(docker --version | grep -oE 'Docker version [0-9]+' | grep -oE '[0-9]+') 
 fi
 
 # check installation directories
-installation_dir=$1
+installation_dir="$1"
 if [ -z "$installation_dir" ]; then
     echo "Please provide an installtion directory with './install.sh /path/to/installation'"
     exit 1
@@ -29,12 +29,12 @@ if [ -f "/etc/systemd/system/redact.service" ]; then
 fi
 
 # copy license and external files
-mkdir $installation_dir
-cp docker-compose.env $installation_dir
-cp docker-compose.yaml $installation_dir
-cp license.bal $installation_dir
-cp start_redact.sh $installation_dir
-cp stop_redact.sh $installation_dir
+mkdir "$installation_dir"
+cp docker-compose.env "$installation_dir"
+cp docker-compose.yaml "$installation_dir"
+cp license.bal "$installation_dir"
+cp start_redact.sh "$installation_dir"
+cp stop_redact.sh "$installation_dir"
 
 # put unit files in directories
 cp redact.service /etc/systemd/system/

--- a/redact.service
+++ b/redact.service
@@ -7,7 +7,7 @@ Requires=docker.service
 TimeoutStartSec=0
 Environment="INSTALLATION_DIR=/etc/redact"
 ExecStartPre=/bin/bash -c '${INSTALLATION_DIR}/stop_redact.sh'
-ExecStart=/bin/bash -c '${INSTALLATION_DIR}/start_redact.sh'
+ExecStart=/bin/bash -c '${INSTALLATION_DIR}/start_redact.sh -a'
 ExecStop=/bin/bash -c '${INSTALLATION_DIR}/stop_redact.sh'
 Type=simple
 

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -2,10 +2,11 @@
 set -o errexit
 set -a
 # systemd service provides installation_dir as an environment variable
-installation_dir=${INSTALLATION_DIR}
-if [ -z $installation_dir ]; then
+if [ -z ${INSTALLATION_DIR} ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
+else
+    installation_dir="$INSTALLATION_DIR"
 fi
 source "$installation_dir/docker-compose.env"
 set +a

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -o errexit
 set -a
-# systemd service provides installation_dir as an environment variable 
+# systemd service provides installation_dir as an environment variable
 installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
-
+fi
 source "$installation_dir/docker-compose.env"
 set +a
 

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -a
 installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
-    installation_dir="."
+    installation_dir=$(realpath ".")
 fi
 source $installation_dir/docker-compose.env
 set +a

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -4,6 +4,7 @@ set -a
 installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
     installation_dir=$(realpath ".")
+    export INSTALLATION_DIR=${installation_dir}
 fi
 source $installation_dir/docker-compose.env
 set +a

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -o errexit
 set -a
+# systemd service provides installation_dir as an environment variable 
+installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
-else
-    installation_dir="$INSTALLATION_DIR"
-fi
 
 source "$installation_dir/docker-compose.env"
 set +a

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
 set -o errexit
 set -a
-installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
-    installation_dir=$(realpath ".")
-    export INSTALLATION_DIR=${installation_dir}
+    installation_dir="$(realpath '.')"
+    export INSTALLATION_DIR="${installation_dir}"
+else
+    installation_dir="$INSTALLATION_DIR"
 fi
-source $installation_dir/docker-compose.env
+
+source "$installation_dir/docker-compose.env"
 set +a
 
-while getopts "ud" opt; do
+while getopts "ua" opt; do
     case $opt in
         u) ui="SET"
         ;;
-        d) detach="SET"
+        d) attach="SET"
         ;;
     esac
 done
 
 # check license file
-if [ ! -f $installation_dir/${REDACT_LICENSE_FILE} ]; then
+if [ ! -f "$installation_dir/${REDACT_LICENSE_FILE}" ]; then
     echo "Please make sure that license file with path \"$installation_dir/${REDACT_LICENSE_FILE}\" exists."
     exit 1
 fi
@@ -47,14 +49,14 @@ if [ ${ui+x} ]; then
 fi
 
 args="--force-recreate --remove-orphans"
-if [ -v detach ]; then
+if [ ! -v attach ]; then
     args="${args} -d"
 fi
 
 export HOST_IP=$(hostname -I | awk '{print $1}')
-docker compose -f $installation_dir/docker-compose.yaml up ${args} ${services}
+docker compose -f "$installation_dir/docker-compose.yaml" up ${args} ${services}
 
-if [ -v detach ]; then
+if [ ! -v attach ]; then
     # print some urls
     echo "redact API running at http://${HOST_IP}:${REDACT_API_PORT}"
     if [ ${ui+x} ]; then

--- a/start_redact.sh
+++ b/start_redact.sh
@@ -15,7 +15,7 @@ while getopts "ua" opt; do
     case $opt in
         u) ui="SET"
         ;;
-        d) attach="SET"
+        a) attach="SET"
         ;;
     esac
 done

--- a/stop_redact.sh
+++ b/stop_redact.sh
@@ -2,10 +2,11 @@
 set -o errexit
 set -a
 # systemd service provides installation_dir as an environment variable
-installation_dir=${INSTALLATION_DIR}
-if [ -z $installation_dir ]; then
+if [ -z ${INSTALLATION_DIR} ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
+else
+    installation_dir="$INSTALLATION_DIR"
 fi
 source "$installation_dir/docker-compose.env"
 set +a

--- a/stop_redact.sh
+++ b/stop_redact.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -o errexit
 set -a
-installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
-    installation_dir="."
+    installation_dir="$(realpath '.')"
+    export INSTALLATION_DIR="${installation_dir}"
+else
+    installation_dir="$INSTALLATION_DIR"
 fi
-source $installation_dir/docker-compose.env
+source "$installation_dir/docker-compose.env"
 set +a
 
 # start containers
 export HOST_IP=$(hostname -I | awk '{print $1}')
-docker compose -f $installation_dir/docker-compose.yaml down --remove-orphans
+docker compose -f "$installation_dir/docker-compose.yaml" down --remove-orphans

--- a/stop_redact.sh
+++ b/stop_redact.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -o errexit
 set -a
-# systemd service provides installation_dir as an environment variable 
+# systemd service provides installation_dir as an environment variable
 installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
-
+fi
 source "$installation_dir/docker-compose.env"
 set +a
 

--- a/stop_redact.sh
+++ b/stop_redact.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -o errexit
 set -a
+# systemd service provides installation_dir as an environment variable 
+installation_dir=${INSTALLATION_DIR}
 if [ -z $installation_dir ]; then
     installation_dir="$(realpath '.')"
     export INSTALLATION_DIR="${installation_dir}"
-else
-    installation_dir="$INSTALLATION_DIR"
-fi
+
 source "$installation_dir/docker-compose.env"
 set +a
 


### PR DESCRIPTION
This PR bumps the version for redact GPU and redact infer to 2.7.0 and 5.14.0. There were issues with passing the paths on starting the deployment via systemd and normal start-up script. 
When there is no valid file passed as a volume, docker compose simply creates a folder instead. This happens silently and can be quite misleading.

Further there was Azure VM set up for testing. [Some documentation](https://brighterai.atlassian.net/wiki/spaces/RD/pages/2720464899/Testing+of+new+Releases+on+Azure+VM).