### PR TITLE
[PHX-1436] chore: bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following GPU-specific containers exist, and can be used only with the speci
 
 | Standard Image   | T4 Optimized Image            | A100 Optimized Image            | 2080TI Optimized Image     |
 |------------------|-------------------------------|---------------------------------|----------------------------|
+| redact-gpu:2.8.0 | redact-gpu:2.8.0-T4           | redact-gpu:2.8.0-A100           | redact-gpu:2.8.0-2080ti    |
 | redact-gpu:2.7.0 | redact-gpu:2.7.0-T4           | redact-gpu:2.7.0-A100           | redact-gpu:2.7.0-2080ti    |
 | redact-gpu:2.6.1 | redact-gpu:2.6.1-T4           | redact-gpu:2.6.1-A100           | redact-gpu:2.6.1-2080ti    |
 | redact-gpu:2.6.0 | redact-gpu:2.6.0-T4           | redact-gpu:2.6.0-A100           | redact-gpu:2.6.0-2080ti    |

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021-2024 Brighter AI Technologies GmbH
 # SPDX-License-Identifier: MIT
-REDACT_IMAGE="docker.brighter.ai/redact:v5.15.0"
-REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.7.0"
+REDACT_IMAGE="docker.brighter.ai/redact:v5.15.1"
+REDACT_GPU_IMAGE="docker.brighter.ai/redact-gpu:2.8.0"
 REDACT_UTILS_IMAGE="docker.brighter.ai/redact-utils:1.1.9"
 
 REDACT_CONTAINER_NAME="redact"


### PR DESCRIPTION
Testing of new images done via redact-enterpr-test VM.

The following images have been released to brighterenterprise.azurcr.io:
`brighterenterprise.azurecr.io/redact:v5.15.1`
`brighterenterprise.azurecr.io/redact-gpu:2.8.0-2080ti`
`brighterenterprise.azurecr.io/redact-gpu:2.8.0-A100`
`brighterenterprise.azurecr.io/redact-gpu:2.8.0-T4`
`brighterenterprise.azurecr.io/redact-gpu:2.8.0`